### PR TITLE
Fix dependency issues

### DIFF
--- a/samples/Aspire/LlamaParseAspire/LlamaParseAspire.csproj
+++ b/samples/Aspire/LlamaParseAspire/LlamaParseAspire.csproj
@@ -8,7 +8,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.5" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 

--- a/src/LlamaIndex.Core/LlamaIndex.Core.csproj
+++ b/src/LlamaIndex.Core/LlamaIndex.Core.csproj
@@ -14,7 +14,7 @@
 
 
 	<ItemGroup>
-		<PackageReference Include="System.Text.Json" Version="8.0.3" />
+		<PackageReference Include="System.Text.Json" Version="8.0.6" />
 	</ItemGroup>
 
 </Project>

--- a/src/LlamaParse/LlamaParse.csproj
+++ b/src/LlamaParse/LlamaParse.csproj
@@ -13,9 +13,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.3.0" />
+		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
-		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
I am working on a project where I would like to consume LlamaParse from a .NET library. The NuGet package is broken, so I want to build it locally. When doing that I've run into two issues: vulnerable dependencies and package version conflicts. This PR fixes both.