### PR TITLE
the "credits_max" property is not mandatory

### DIFF
--- a/src/LlamaParse/LlamaParseApiClient.cs
+++ b/src/LlamaParse/LlamaParseApiClient.cs
@@ -54,7 +54,7 @@ internal class LlamaParseApiClient(HttpClient client, string apiKey, string endp
             jsonElement,
             null,
             jobMetaData.GetProperty(Constants.CreditsUsedKey).GetDouble(),
-            jobMetaData.GetProperty(Constants.CreditsMaxKey).GetDouble(),
+            jobMetaData.TryGetProperty(Constants.CreditsMaxKey, out var property) ? property.GetDouble() : -1,
             jobMetaData.GetProperty(Constants.JobCreditsUsageKey).GetDouble(),
             jobMetaData.GetProperty(Constants.JobPagesKey).GetDouble(),
             jobMetaData.GetProperty(Constants.JobIsCacheHitKey).GetBoolean());


### PR DESCRIPTION
I am using the free LlamaCloud account and when using the library I've been getting `KeyNotFoundException`. The following change checks if  "credits_max" is present, if not is uses `-1`.

cc @logan-markewich @Javtor